### PR TITLE
fix: datagrid item detail hover selector

### DIFF
--- a/assets/scss/_datagrid.scss
+++ b/assets/scss/_datagrid.scss
@@ -247,7 +247,7 @@
 			z-index: 99;
 		}
 
-		tr:hover {
+		tr:not(.row-item-detail):hover {
 			td {
 				background-color: $background-dark;
 			}


### PR DESCRIPTION
Prevents the hover background color from being applied to detail rows in the datagrid by excluding .row-item-detail from the hover selector.