### PR TITLE
Enforces permission check on sign-in

### DIFF
--- a/src/UI/Components/Forms/SignIn/SignInFormTrait.php
+++ b/src/UI/Components/Forms/SignIn/SignInFormTrait.php
@@ -105,6 +105,15 @@ trait SignInFormTrait
 	{
 		try {
 			$this->_identity = $this->_authenticator->authenticate($values['email'], $values['password'], $this->_fancyAdmin->getContext());
+
+			if (
+				!$this->_identity->isAllowed($this->_fancyAdmin->getCustomerAclResource())
+				&&
+				!$this->_identity->isAllowed($this->_fancyAdmin->getBackofficeAclResource())
+			) {
+				$form->addError('fcadmin.appGeneral.exceptions.noPermission');
+			}
+
 		} catch (AuthenticationException) {
 			$form->addError('fcadmin.appGeneral.exceptions.wrongCredentials');
 		}

--- a/src/lang/fcadmin.cs.yml
+++ b/src/lang/fcadmin.cs.yml
@@ -307,6 +307,7 @@ appGeneral:
   exceptions:
     userNotFound: "Uživatel nenalezen"
     wrongCredentials: "Neplatné přihlašovací údaje"
+    noPermission: "Nemáte právo pro přihlášení"
     inactiveUser: "Neaktivní uživatel"
 
 sidePanels:


### PR DESCRIPTION
Prevents users from signing in if they lack the required customer or backoffice ACL resources. This ensures only users with appropriate permissions can access the administrative interface, improving security and providing clearer feedback during login attempts.

Adds a new localized error message for permission denied.