### PR TITLE
fix: parent-aware kontrola profilu v SelectAccount listeneru

### DIFF
--- a/src/Model/Listeners/SelectAccountListenerTrait.php
+++ b/src/Model/Listeners/SelectAccountListenerTrait.php
@@ -56,11 +56,18 @@ trait SelectAccountListenerTrait
 				$this->entitiesToRecompute[] = $identity;
 			}
 
-			// 2) nemá full data přístup, má nastavený selectedAccount, ale odpovídající profil je neaktivní
+			// 2) nemá full data přístup, má nastavený selectedAccount, ale nemá pro něj
+			//    (ani pro jeho nadřazený účet) aktivní profil. Parent-aware shoda je konzistentní
+			//    s Identity::getProfile() i s tím, že SelectAccountForm nabízí přes getSubaccounts()
+			//    i subúčty - majitel holdingu má profil jen na nadřazeném účtu.
 			if (!$hasFullData && $selectedAccount) {
+				$parentAccount = $selectedAccount->getParent();
 				$profileIsActive = false;
 				foreach ($identity->getProfiles() as $_profile) {
-					if ($_profile->getAccount() === $selectedAccount && $_profile->getIsActive()) {
+					if (
+						$_profile->getIsActive()
+						&& ($_profile->getAccount() === $selectedAccount || $_profile->getAccount() === $parentAccount)
+					) {
 						$profileIsActive = true;
 						break;
 					}


### PR DESCRIPTION
Listener po výběru účtu validoval aktivní profil jen přes přímou shodu účtu, takže výběr subúčtu (kde uživatel nemá vlastní profil) resetoval selectedAccount na první aktivní profil. To bylo nekonzistentní s:
- Identity::getProfile(), které je parent-aware (subúčet -> profil rodiče),
- SelectAccountFormTrait::getAccountPairs(), které subúčty přes getSubaccounts() aktivně nabízí.

Majitel holdingu má profil jen na nadřazeném účtu, ale potřebuje přepínat i na jeho subúčty. Kontrola nově uznává aktivní profil i na nadřazeném účtu.