### PR TITLE
Enhances grid search field customization

### DIFF
--- a/src/UI/Components/Grids/Account/AccountGridTrait.php
+++ b/src/UI/Components/Grids/Account/AccountGridTrait.php
@@ -9,15 +9,17 @@ use ADT\FancyAdmin\DI\Injects\FancyAdminInject;
 use ADT\FancyAdmin\Model\Entities\Account;
 use ADT\FancyAdmin\Model\Queries\Factories\AccountQueryFactory;
 use ADT\FancyAdmin\UI\Components\Grids\Traits\Editable\Editable;
+use ADT\FancyAdmin\UI\Components\Grids\Traits\SearchFilter;
 
 trait AccountGridTrait
 {
 	use Editable;
 	use FancyAdminInject;
+	use SearchFilter;
 
 	public function initGrid(DataGrid $grid): void
 	{
-		$grid->addFilterText('search', '', ['name']);
+		$this->addSearchFilter($grid, ['name']);
 
 		$grid->addColumnText('name', 'fcadmin.grids.account.name');
 

--- a/src/UI/Components/Grids/ChangeLog/ChangeLogGridTrait.php
+++ b/src/UI/Components/Grids/ChangeLog/ChangeLogGridTrait.php
@@ -12,12 +12,15 @@ use ADT\DoctrineLoggable\Entity\ChangeLog;
 use ADT\FancyAdmin\Model\Attributes\Label;
 use ADT\FancyAdmin\Model\Entities\Identity;
 use ADT\FancyAdmin\Model\Queries\Factories\ChangeLogQueryFactory;
+use ADT\FancyAdmin\UI\Components\Grids\Traits\SearchFilter;
 use Nette\Utils\Html;
 use Nette\Utils\Strings;
 use ReflectionClass;
 
 trait ChangeLogGridTrait
 {
+	use SearchFilter;
+
 	public function initGrid(DataGrid $grid): void
 	{
 		$this->withoutIsActiveColumn = true;
@@ -53,7 +56,7 @@ trait ChangeLogGridTrait
 				return $this->renderChangeSet($changeLog);
 			});
 
-		$grid->addFilterText('search', '', ['objectClass', 'objectId']);
+		$this->addSearchFilter($grid, ['objectClass', 'objectId']);
 
 		$grid->addFilterSelect('action', 'fcadmin.grids.changeLog.action', [
 			'create' => $this->getTranslator()->translate('fcadmin.grids.changeLog.actions.create'),

--- a/src/UI/Components/Grids/Identity/IdentityGridTrait.php
+++ b/src/UI/Components/Grids/Identity/IdentityGridTrait.php
@@ -5,11 +5,6 @@ declare(strict_types=1);
 namespace ADT\FancyAdmin\UI\Components\Grids\Identity;
 
 use ADT\Datagrid\Component\DataGrid;
-use ADT\FancyAdmin\DI\Injects\EntityManagerInject;
-use ADT\FancyAdmin\DI\Injects\IdentityQueryFactoryInject;
-use ADT\FancyAdmin\DI\Injects\MailerInject;
-use ADT\FancyAdmin\DI\Injects\SecurityUserInject;
-use ADT\FancyAdmin\Model\Entities\Enums\AclResourceNameEnum;
 use ADT\FancyAdmin\Model\Entities\Identity;
 use ADT\FancyAdmin\Model\Queries\Factories\IdentityQueryFactory;
 use ADT\FancyAdmin\UI\Components\Grids\Traits\AnonymizeIdentity\AnonymizeIdentity;
@@ -17,9 +12,6 @@ use ADT\FancyAdmin\UI\Components\Grids\Traits\Editable\Editable;
 use ADT\FancyAdmin\UI\Components\Grids\Traits\IdentityData;
 use ADT\FancyAdmin\UI\Components\Grids\Traits\ResetPassword\ResetPassword;
 use ADT\FancyAdmin\UI\Components\Grids\Traits\SignInAsIdentity\SignInAsIdentity;
-use ADT\FancyAdmin\UI\Presenters\SecurityCheckAttribute;
-use Exception;
-use ReflectionException;
 
 trait IdentityGridTrait
 {
@@ -29,9 +21,9 @@ trait IdentityGridTrait
 	use IdentityData;
 	use AnonymizeIdentity;
 
-	public function initGrid(DataGrid $grid, array $searchFields = []): void
+	public function initGrid(DataGrid $grid): void
 	{
-		$this->addIdentityData($grid, searchFields: $searchFields);
+		$this->addIdentityData($grid);
 
 		$grid->addColumnText('roles', 'fcadmin.grids.user.labels.roles')
 			->setRenderer(function (Identity $identity) {

--- a/src/UI/Components/Grids/Identity/IdentityGridTrait.php
+++ b/src/UI/Components/Grids/Identity/IdentityGridTrait.php
@@ -29,9 +29,9 @@ trait IdentityGridTrait
 	use IdentityData;
 	use AnonymizeIdentity;
 
-	public function initGrid(DataGrid $grid): void
+	public function initGrid(DataGrid $grid, array $searchFields = []): void
 	{
-		$this->addIdentityData($grid);
+		$this->addIdentityData($grid, searchFields: $searchFields);
 
 		$grid->addColumnText('roles', 'fcadmin.grids.user.labels.roles')
 			->setRenderer(function (Identity $identity) {

--- a/src/UI/Components/Grids/Profile/ProfileGridTrait.php
+++ b/src/UI/Components/Grids/Profile/ProfileGridTrait.php
@@ -21,9 +21,9 @@ trait ProfileGridTrait
 	use ResetPassword;
 	use SignInAsIdentity;
 
-	public function initGrid(DataGrid $grid, array $searchFields = []): void
+	public function initGrid(DataGrid $grid): void
 	{
-		$this->addIdentityData($grid, columnPrefix: 'identity.', searchFields: $searchFields);
+		$this->addIdentityData($grid, columnPrefix: 'identity.');
 
 		$grid->addColumnText('roles', 'fcadmin.grids.user.labels.roles')
 			->setRenderer(function (Profile $profile) {

--- a/src/UI/Components/Grids/Profile/ProfileGridTrait.php
+++ b/src/UI/Components/Grids/Profile/ProfileGridTrait.php
@@ -21,9 +21,9 @@ trait ProfileGridTrait
 	use ResetPassword;
 	use SignInAsIdentity;
 
-	public function initGrid(DataGrid $grid): void
+	public function initGrid(DataGrid $grid, array $searchFields = []): void
 	{
-		$this->addIdentityData($grid, 'identity.');
+		$this->addIdentityData($grid, columnPrefix: 'identity.', searchFields: $searchFields);
 
 		$grid->addColumnText('roles', 'fcadmin.grids.user.labels.roles')
 			->setRenderer(function (Profile $profile) {

--- a/src/UI/Components/Grids/Traits/IdentityData.php
+++ b/src/UI/Components/Grids/Traits/IdentityData.php
@@ -6,9 +6,11 @@ use ADT\Datagrid\Component\DataGrid;
 
 trait IdentityData
 {
-	protected function addIdentityData(DataGrid $grid, string $columnPrefix = '', array $searchFields = []): void
+	use SearchFilter;
+
+	protected function addIdentityData(DataGrid $grid, string $columnPrefix = ''): void
 	{
-		$grid->addFilterText('search', '', array_unique(array_merge([$columnPrefix . 'firstName', $columnPrefix . 'lastName', $columnPrefix . 'email', $columnPrefix . 'phoneNumber'], $searchFields)));
+		$this->addSearchFilter($grid, [$columnPrefix . 'firstName', $columnPrefix . 'lastName', $columnPrefix . 'email', $columnPrefix . 'phoneNumber']);
 		$grid->addColumnText('fullName', 'fcadmin.grids.user.labels.fullName', $columnPrefix . 'fullName');
 		$grid->addColumnText('email', 'fcadmin.grids.user.labels.email', $columnPrefix . 'email');
 		$grid->addColumnText('phoneNumber', 'fcadmin.grids.user.labels.phoneNumber', $columnPrefix . 'phoneNumber');

--- a/src/UI/Components/Grids/Traits/IdentityData.php
+++ b/src/UI/Components/Grids/Traits/IdentityData.php
@@ -6,9 +6,9 @@ use ADT\Datagrid\Component\DataGrid;
 
 trait IdentityData
 {
-	protected function addIdentityData(DataGrid $grid, string $columnPrefix = ''): void
+	protected function addIdentityData(DataGrid $grid, string $columnPrefix = '', array $searchFields = []): void
 	{
-		$grid->addFilterText('search', '', [$columnPrefix . 'firstName', $columnPrefix . 'lastName', $columnPrefix . 'email', $columnPrefix . 'phoneNumber']);
+		$grid->addFilterText('search', '', array_unique(array_merge([$columnPrefix . 'firstName', $columnPrefix . 'lastName', $columnPrefix . 'email', $columnPrefix . 'phoneNumber'], $searchFields)));
 		$grid->addColumnText('fullName', 'fcadmin.grids.user.labels.fullName', $columnPrefix . 'fullName');
 		$grid->addColumnText('email', 'fcadmin.grids.user.labels.email', $columnPrefix . 'email');
 		$grid->addColumnText('phoneNumber', 'fcadmin.grids.user.labels.phoneNumber', $columnPrefix . 'phoneNumber');

--- a/src/UI/Components/Grids/Traits/SearchFilter.php
+++ b/src/UI/Components/Grids/Traits/SearchFilter.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ADT\FancyAdmin\UI\Components\Grids\Traits;
+
+use ADT\Datagrid\Component\DataGrid;
+
+trait SearchFilter
+{
+	/** @var string[]
+	 *
+	 * Dodatečná pole pro fulltextový filtr "search"; lze nastavit třemi způsoby:
+	 *
+	 * A) Override initGrid v komponentě (nejexplicitnější):
+	 * use ProfileGridTrait {
+	 *  ProfileGridTrait::initGrid as traitInitGrid;
+	 * }
+	 *
+	 * public function initGrid(DataGrid $grid): void
+	 * {
+	 *  $this->searchFields = ['identity.username'];
+	 *  $this->traitInitGrid($grid);
+	 * }
+	 *
+	 * B) Přes setter při vytváření komponenty (před
+	 * připojením k presenteru):
+	 * protected function createComponentProfileGrid(): ProfileGrid
+	 * {
+	 *  $grid = $this->profileGridFactory->create();
+	 *  $grid->setSearchFields(['identity.username']);
+	 *  return $grid;
+	 * }
+	 *
+	 * C) V konstruktoru komponenty (jen zaregistruje monitor, initGrid ještě neběží):
+	 * public function __construct()
+	 * {
+	 *  parent::__construct();
+	 *  $this->searchFields = ['identity.username'];
+	 * }
+	 *
+	 */
+	protected array $searchFields = [];
+
+	/**
+	 * Přidá fulltextový filtr "search" sloučený z výchozích polí gridu a případných polí nastavených přes setSearchFields().
+	 *
+	 * @param string[] $defaultSearchFields výchozí pole, která prohledává daný grid
+	 */
+	protected function addSearchFilter(DataGrid $grid, array $defaultSearchFields = []): void
+	{
+		$grid->addFilterText('search', '', array_unique(array_merge($defaultSearchFields, $this->searchFields)));
+	}
+
+	/**
+	 * @param string[] $searchFields
+	 */
+	public function setSearchFields(array $searchFields): static
+	{
+		$this->searchFields = $searchFields;
+		return $this;
+	}
+}


### PR DESCRIPTION
Adds an optional parameter to include custom search fields in identity-related grids. This allows for greater flexibility when defining the fields used in the general search filter, extending beyond the default first name, last name, email, and phone number.