### PR TITLE
feat(passkey): add passkeyEnabled flag and conditional passkey UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1240,10 +1240,18 @@ Pro použití vlastní třídy je potřeba rozšířit `KeycloakManager::createI
 ## 19. Passkeys (WebAuthn)
 
 Fancyadmin podporuje přihlašování přes passkeys (WebAuthn) postavené na knihovně
-[lbuchs/webauthn](https://github.com/lbuchs/WebAuthn). Passkeys jsou **vždy zapnuté** —
-žádný config flag; passkey je vždy jen alternativa k heslu (žádné passkey-only účty).
-Identity navázané na Keycloak SSO se přes passkey přihlásit ani registrovat klíč nemohou
-(autorita pro SSO účty je Keycloak).
+[lbuchs/webauthn](https://github.com/lbuchs/WebAuthn). Passkeys jsou **opt-in** — zapínají
+se configem `passkeyEnabled: true` (default `false`, viz 19.2). Při vypnuté featuře se
+nevykresluje tlačítko na login stránce ani karta v Můj účet a všechny passkey operace
+jsou zablokované i server-side (`PasskeyService::assertEnabled()`). Existující klíče
+v DB při vypnutí zůstávají — po opětovném zapnutí zase fungují. Passkey je vždy jen
+alternativa k heslu (žádné passkey-only účty). Identity navázané na Keycloak SSO se přes
+passkey přihlásit ani registrovat klíč nemohou (autorita pro SSO účty je Keycloak).
+
+Při `passkeyEnabled: false` (default) projekt **nemusí mít žádné passkey třídy** —
+entitu, query, factory, form ani grid (sekce 19.3-19.5). Při `passkeyEnabled: true`
+jsou povinné; extension to zvaliduje při kompilaci DI kontejneru a chybějící
+infrastrukturu ohlásí srozumitelnou chybou.
 
 Co uživatel dostane:
 
@@ -1260,16 +1268,20 @@ Co uživatel dostane:
 - **rpId = doména admin hostu** — klíče jsou svázané s doménou; změna domény znamená
   ztrátu registrovaných klíčů. Default se odvozuje z `adminHostPath`.
 
-### 19.2 NEON konfigurace (volitelné)
+### 19.2 NEON konfigurace
 
 ```neon
 fancyadmin:
     # ... ostatní konfigurace ...
+    # Zapnutí passkeys — bez tohoto flagu je celá featura vypnutá (default: false)
+    passkeyEnabled: true
     # Relying Party ID — doména; když není nastaveno, odvodí se host z adminHostPath
     passkeyRpId: admin.muj-projekt.cz
     # Relying Party name — zobrazuje se v dialogu autentikátoru; default = projectName
     passkeyRpName: Můj projekt
 ```
+
+Povinné je jen `passkeyEnabled` (pro zapnutí), `passkeyRpId` a `passkeyRpName` jsou volitelné.
 
 ### 19.3 Entita Passkey
 

--- a/src/DI/FancyAdminExtension.php
+++ b/src/DI/FancyAdminExtension.php
@@ -17,6 +17,7 @@ use ADT\FancyAdmin\Model\Entities\IdentityTrait;
 use ADT\FancyAdmin\Model\Entities\Profile;
 use ADT\FancyAdmin\Model\Entities\ProfileTrait;
 use ADT\FancyAdmin\Model\FancyAdmin;
+use ADT\FancyAdmin\Model\Queries\Factories\PasskeyQueryFactory;
 use ADT\FancyAdmin\Model\Security\Authenticator;
 use ADT\FancyAdmin\Model\Security\Keycloak\KeycloakManager;
 use ADT\FancyAdmin\Model\Security\Passkey\PasskeyService;
@@ -64,6 +65,7 @@ class FancyAdminExtension extends CompilerExtension implements TranslationProvid
 			'keycloakEnabled' => Expect::bool()->default(false),
 			// Vypnutí validace TLS certifikátu Keycloak serveru — POUZE pro lokální vývoj (self-signed cert)
 			'keycloakVerifySsl' => Expect::bool()->default(true),
+			'passkeyEnabled' => Expect::bool()->default(false),
 			// WebAuthn Relying Party ID (doména) — když není nastaveno, odvodí se za běhu host z adminHostPath
 			'passkeyRpId' => Expect::string()->nullable()->default(null),
 			// WebAuthn Relying Party name — když není nastaveno, použije se projectName
@@ -126,6 +128,7 @@ class FancyAdminExtension extends CompilerExtension implements TranslationProvid
 				'context' => $this->config->context,
 				'colors' => (array) $this->config->colors,
 				'keycloakEnabled' => $this->config->keycloakEnabled,
+				'passkeyEnabled' => $this->config->passkeyEnabled,
 				'passkeyRpId' => $this->config->passkeyRpId,
 				'passkeyRpName' => $this->config->passkeyRpName,
 			]);
@@ -178,6 +181,12 @@ class FancyAdminExtension extends CompilerExtension implements TranslationProvid
 		if ($this->config->keycloakEnabled) {
 			$fancyAdminDef = $builder->getDefinition($this->prefix('administration'));
 			$fancyAdminDef->addSetup('setKeycloakManager', [$this->prefix('@keycloakManager')]);
+		}
+
+		// passkeyEnabled vyžaduje passkey infrastrukturu v projektu — srozumitelná chyba
+		// při kompilaci kontejneru místo kryptické autowiring hlášky za běhu
+		if ($this->config->passkeyEnabled && $builder->getByType(PasskeyQueryFactory::class) === null) {
+			throw new RuntimeException('fancyadmin: passkeyEnabled je zapnuté, ale v projektu chybí implementace ' . PasskeyQueryFactory::class . '. Vytvořte entitu Passkey, PasskeyQuery, PasskeyQueryFactory, PasskeyForm a PasskeyGrid podle README (sekce 19), nebo passkeys vypněte.');
 		}
 	}
 

--- a/src/Model/Entities/Identity.php
+++ b/src/Model/Entities/Identity.php
@@ -57,10 +57,6 @@ interface Identity extends DoctrineAuthenticatorIdentity, IsActiveInterface, Ent
 	public function getSso(): ?Sso;
 	public function setSso(?Sso $sso): static;
 
-	/**
-	 * @return Passkey[]
-	 */
-	public function getPasskeys(): array;
 	public function getPasskeyUserHandle(): ?string;
 	public function setPasskeyUserHandle(?string $passkeyUserHandle): static;
 

--- a/src/Model/Entities/IdentityTrait.php
+++ b/src/Model/Entities/IdentityTrait.php
@@ -77,9 +77,8 @@ trait IdentityTrait
 	#[LoggableProperty]
 	protected Collection $roles;
 
-	#[ORM\OneToMany(targetEntity: 'Passkey', mappedBy: 'identity')]
-	protected Collection $passkeys;
-
+	// Vazba na passkeys je jen jednosměrná (Passkey ManyToOne identity v PasskeyTrait) —
+	// entita Passkey je v projektu volitelná, Identity na ní nesmí záviset
 	#[ORM\Column(type: 'binary', length: 32, nullable: true, options: ['fixed' => true])]
 	protected mixed $passkeyUserHandle = null;
 
@@ -98,7 +97,6 @@ trait IdentityTrait
 	{
 		$this->profiles = new ArrayCollection();
 		$this->roles = new ArrayCollection();
-		$this->passkeys = new ArrayCollection();
 	}
 
 	public function getPassword(): ?string
@@ -349,14 +347,6 @@ trait IdentityTrait
 	public function getIdentity(): Identity
 	{
 		return $this;
-	}
-
-	/**
-	 * @return Passkey[]
-	 */
-	public function getPasskeys(): array
-	{
-		return $this->passkeys->toArray();
 	}
 
 	public function getPasskeyUserHandle(): ?string

--- a/src/Model/FancyAdmin.php
+++ b/src/Model/FancyAdmin.php
@@ -29,6 +29,7 @@ class FancyAdmin
 		protected array $jsComponentsConfig = [],
 		protected array $colors = [],
 		protected bool $keycloakEnabled = false,
+		protected bool $passkeyEnabled = false,
 		protected ?string $passkeyRpId = null,
 		protected ?string $passkeyRpName = null,
 	) {}
@@ -172,6 +173,11 @@ class FancyAdmin
 	public function isKeycloakEnabled(): bool
 	{
 		return $this->keycloakEnabled;
+	}
+
+	public function isPasskeyEnabled(): bool
+	{
+		return $this->passkeyEnabled;
 	}
 
 	public function getPasskeyRpId(): ?string

--- a/src/Model/Security/Passkey/PasskeyService.php
+++ b/src/Model/Security/Passkey/PasskeyService.php
@@ -16,6 +16,7 @@ use lbuchs\WebAuthn\WebAuthnException;
 use Nette\Http\Session;
 use Nette\Http\SessionSection;
 use Nette\Localization\Translator;
+use RuntimeException;
 use stdClass;
 use Throwable;
 
@@ -39,8 +40,10 @@ class PasskeyService
 		protected EntityManager $em,
 		protected Session $session,
 		protected FancyAdmin $fancyAdmin,
-		protected PasskeyQueryFactory $passkeyQueryFactory,
 		protected Translator $translator,
+		// nullable — passkey infrastruktura (entita, query, factory) je v projektu volitelná,
+		// služba se ale musí dát vytvořit vždy (injectuje se v traitech přes PasskeyServiceInject)
+		protected ?PasskeyQueryFactory $passkeyQueryFactory = null,
 	) {}
 
 	/**
@@ -51,6 +54,7 @@ class PasskeyService
 	 */
 	public function getRegistrationArgs(Identity $identity): stdClass
 	{
+		$this->assertEnabled();
 		$this->assertNotSso($identity);
 
 		// Lazy vygenerování opaque user handle — autentikátoru nikdy neposíláme interní ID identity
@@ -60,7 +64,8 @@ class PasskeyService
 		}
 
 		$excludeCredentialIds = [];
-		foreach ($identity->getPasskeys() as $passkey) {
+		/** @var Passkey $passkey */
+		foreach ($this->getPasskeyQueryFactory()->create()->disableSecurityFilter()->disableAccountFilter()->byIdentity($identity)->fetch() as $passkey) {
 			$excludeCredentialIds[] = $passkey->getCredentialId();
 		}
 
@@ -97,6 +102,7 @@ class PasskeyService
 		?array $transports = null,
 	): Passkey
 	{
+		$this->assertEnabled();
 		$this->assertNotSso($identity);
 
 		$name = $this->normalizeName($name);
@@ -117,7 +123,7 @@ class PasskeyService
 
 		$credentialId = $data->credentialId;
 
-		if ($this->passkeyQueryFactory->create()->disableSecurityFilter()->disableAccountFilter()->byCredentialId($credentialId)->count() > 0) {
+		if ($this->getPasskeyQueryFactory()->create()->disableSecurityFilter()->disableAccountFilter()->byCredentialId($credentialId)->count() > 0) {
 			throw new PasskeyException($this->translator->translate('fcadmin.passkeys.errors.alreadyRegistered'));
 		}
 
@@ -154,6 +160,8 @@ class PasskeyService
 	 */
 	public function getLoginArgs(): stdClass
 	{
+		$this->assertEnabled();
+
 		$webAuthn = $this->createWebAuthn();
 		$args = $webAuthn->getGetArgs(
 			[],
@@ -186,10 +194,12 @@ class PasskeyService
 		?string $userHandle = null,
 	): Identity
 	{
+		$this->assertEnabled();
+
 		$challenge = $this->consumeChallenge(PasskeySessionSection::GET_CHALLENGE);
 
 		/** @var Passkey|null $passkey */
-		$passkey = $this->passkeyQueryFactory->create()
+		$passkey = $this->getPasskeyQueryFactory()->create()
 			->disableSecurityFilter()
 			->disableAccountFilter()
 			->byCredentialId($credentialId)
@@ -237,6 +247,32 @@ class PasskeyService
 		$this->em->flush();
 
 		return $identity;
+	}
+
+	/**
+	 * Server-side vynucení opt-in configu (fancyadmin: passkeyEnabled) —
+	 * musí fungovat i kdyby UI někde zůstalo viditelné.
+	 *
+	 * @throws PasskeyException pokud passkeys nejsou v configu zapnuté
+	 */
+	public function assertEnabled(): void
+	{
+		if (!$this->fancyAdmin->isPasskeyEnabled()) {
+			throw new PasskeyException($this->translator->translate('fcadmin.passkeys.errors.unavailable'));
+		}
+	}
+
+	/**
+	 * @throws RuntimeException pokud projekt nemá zaregistrovanou passkey infrastrukturu —
+	 * chyba konfigurace, ne uživatele (FancyAdminExtension ji při passkeyEnabled hlídá už při kompilaci)
+	 */
+	protected function getPasskeyQueryFactory(): PasskeyQueryFactory
+	{
+		if ($this->passkeyQueryFactory === null) {
+			throw new RuntimeException('V projektu chybí implementace ' . PasskeyQueryFactory::class . ' — vytvořte entitu Passkey, query a factory podle README (sekce 19).');
+		}
+
+		return $this->passkeyQueryFactory;
 	}
 
 	/**

--- a/src/UI/Components/Forms/SignIn/SignInForm.latte
+++ b/src/UI/Components/Forms/SignIn/SignInForm.latte
@@ -5,6 +5,7 @@
 {/define}
 
 {define section-passkey}
+	{if $isPasskeyEnabled}
 	<div
 		class="passkey-login mt-3"
 		data-adt-fancyadmin-passkey-login
@@ -19,4 +20,5 @@
 		</button>
 		<div class="alert alert-danger mt-2 d-none" data-passkey-error></div>
 	</div>
+	{/if}
 {/define}

--- a/src/UI/Components/Forms/SignIn/SignInFormTrait.php
+++ b/src/UI/Components/Forms/SignIn/SignInFormTrait.php
@@ -55,9 +55,12 @@ trait SignInFormTrait
 		$form->addSubmit('submit', 'fcadmin.forms.signIn.labels.logIn')
 			->getControlPrototype()->class[] = 'w-100';
 
-		$form->addSection(name: 'passkey');
+		if ($this->_fancyAdmin->isPasskeyEnabled()) {
+			$form->addSection(name: 'passkey');
+		}
 
 		$this->getTemplate()->isLostPasswordEnabled = $this->_fancyAdmin->isLostPasswordEnabled();
+		$this->getTemplate()->isPasskeyEnabled = $this->_fancyAdmin->isPasskeyEnabled();
 
 		// Keycloak email check — přidá data atribut pro JS kontrolu
 		if ($this->_fancyAdmin->isKeycloakEnabled()) {

--- a/src/UI/Presenters/Account/AccountPresenterTrait.php
+++ b/src/UI/Presenters/Account/AccountPresenterTrait.php
@@ -7,13 +7,13 @@ namespace ADT\FancyAdmin\UI\Presenters\Account;
 use ADT\FancyAdmin\DI\Injects\AuthenticatorInject;
 use ADT\FancyAdmin\DI\Injects\ChangePasswordFormFactoryInject;
 use ADT\FancyAdmin\DI\Injects\FancyAdminInject;
-use ADT\FancyAdmin\DI\Injects\PasskeyFormFactoryInject;
 use ADT\FancyAdmin\DI\Injects\PasskeyServiceInject;
 use ADT\FancyAdmin\DI\Injects\PersonalDataFormFactoryInject;
 use ADT\FancyAdmin\DI\Injects\SecurityUserInject;
 use ADT\FancyAdmin\DI\Injects\TranslatorInject;
 use ADT\FancyAdmin\Model\Security\Passkey\PasskeyException;
 use ADT\FancyAdmin\Model\Security\Passkey\PasskeyService;
+use ADT\FancyAdmin\UI\Components\Forms\Passkey\PasskeyFormFactory;
 use ADT\FancyAdmin\UI\Components\Controls\SidePanel\SidePanelControl;
 use ADT\FancyAdmin\UI\Components\Controls\SidePanel\SidePanelControlFactory;
 use ADT\FancyAdmin\UI\Components\Grids\Passkey\PasskeyGrid;
@@ -23,6 +23,7 @@ use ADT\FancyAdmin\UI\Components\Grids\Session\SessionGridFactory;
 use ADT\FancyAdmin\UI\Presenters\PresenterTrait;
 use Nette\Utils\Json;
 use Nette\Utils\JsonException;
+use RuntimeException;
 
 trait AccountPresenterTrait
 {
@@ -32,7 +33,6 @@ trait AccountPresenterTrait
 	use PersonalDataFormFactoryInject;
 	use ChangePasswordFormFactoryInject;
 	use FancyAdminInject;
-	use PasskeyFormFactoryInject;
 	use PasskeyServiceInject;
 	use TranslatorInject;
 
@@ -46,6 +46,7 @@ trait AccountPresenterTrait
 		}
 
 		$this->getTemplate()->identity = $this->_securityUser->getIdentity();
+		$this->getTemplate()->isPasskeyEnabled = $this->_fancyAdmin->isPasskeyEnabled();
 		$this->getTemplate()->setFile(__DIR__ . '/default.latte');
 	}
 
@@ -101,15 +102,22 @@ trait AccountPresenterTrait
 		return $factory->create();
 	}
 
-	public function createComponentPasskeyGrid(PasskeyGridFactory $factory): PasskeyGrid
+	// Passkey factories jsou nullable — projekt bez passkey tříd je nemá zaregistrované
+	// a kdyby/autowired validuje parametry všech createComponent* metod už při attachi presenteru
+	public function createComponentPasskeyGrid(?PasskeyGridFactory $factory = null): PasskeyGrid
 	{
+		if ($factory === null) {
+			throw new RuntimeException('V projektu chybí implementace ' . PasskeyGridFactory::class . ' — vytvořte passkey třídy podle README (sekce 19).');
+		}
+
 		return $factory->create();
 	}
 
 	public function handleAddPasskey(): void
 	{
-		// SSO uživatel klíč registrovat nesmí — panel se ani neotevře
+		// Vypnutá featura nebo SSO uživatel — panel se ani neotevře
 		try {
+			$this->_passkeyService->assertEnabled();
 			$this->_passkeyService->assertNotSso($this->_securityUser->getIdentity());
 		} catch (PasskeyException $e) {
 			$this->flashMessageError($e->getMessage());
@@ -171,9 +179,13 @@ trait AccountPresenterTrait
 		$this->getPresenter()->redirect('this');
 	}
 
-	public function createComponentAddPasskeySidePanel(SidePanelControlFactory $factory): SidePanelControl
+	public function createComponentAddPasskeySidePanel(SidePanelControlFactory $factory, ?PasskeyFormFactory $passkeyFormFactory = null): SidePanelControl
 	{
+		if ($passkeyFormFactory === null) {
+			throw new RuntimeException('V projektu chybí implementace ' . PasskeyFormFactory::class . ' — vytvořte passkey třídy podle README (sekce 19).');
+		}
+
 		return $factory->create()
-			->setFormFactory(fn() => $this->_passkeyFormFactory->create());
+			->setFormFactory(fn() => $passkeyFormFactory->create());
 	}
 }

--- a/src/UI/Presenters/Account/default.latte
+++ b/src/UI/Presenters/Account/default.latte
@@ -38,17 +38,19 @@
 	</div>
 </div>
 
-<div class="header mt-4">
-	<h2 class="header-title">
-		{_fcadmin.passkeys.account.title}
-	</h2>
+{if $isPasskeyEnabled}
+	<div class="header mt-4">
+		<h2 class="header-title">
+			{_fcadmin.passkeys.account.title}
+		</h2>
 
-	<div class="header-actions">
-		<a n:href="addPasskey!" class="btn btn-primary ajax">{_fcadmin.passkeys.account.add}</a>
+		<div class="header-actions">
+			<a n:href="addPasskey!" class="btn btn-primary ajax">{_fcadmin.passkeys.account.add}</a>
+		</div>
 	</div>
-</div>
 
-{control passkeyGrid}
+	{control passkeyGrid}
+{/if}
 
 <div class="header mt-4">
 	<h2 class="header-title">


### PR DESCRIPTION
- Replace implicit passkey availability with explicit `passkeyEnabled` boolean on FancyAdmin config object
- Wrap passkey section in account view with `{if $isPasskeyEnabled}` so it only renders when the feature is configured
- Inject PasskeyFormFactory directly via use statement instead of through a separate inject trait
- Add PasskeyQueryFactory import to DI extension
- Add RuntimeException import to AccountPresenterTrait