### PR TITLE
refactor(passkey): extract passkey logic into dedicated trait and int…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1249,7 +1249,8 @@ alternativa k heslu (žádné passkey-only účty). Identity navázané na Keycl
 passkey přihlásit ani registrovat klíč nemohou (autorita pro SSO účty je Keycloak).
 
 Při `passkeyEnabled: false` (default) projekt **nemusí mít žádné passkey třídy** —
-entitu, query, factory, form ani grid (sekce 19.3-19.5). Při `passkeyEnabled: true`
+entitu, query, factory, form, grid ani passkey trait v Identity (sekce 19.3-19.5);
+v tabulce `identity` pak není žádný passkey sloupec. Při `passkeyEnabled: true`
 jsou povinné; extension to zvaliduje při kompilaci DI kontejneru a chybějící
 infrastrukturu ohlásí srozumitelnou chybou.
 
@@ -1283,7 +1284,23 @@ fancyadmin:
 
 Povinné je jen `passkeyEnabled` (pro zapnutí), `passkeyRpId` a `passkeyRpName` jsou volitelné.
 
-### 19.3 Entita Passkey
+### 19.3 Entity — Passkey + rozšíření Identity
+
+Entita Identity musí použít `IdentityPasskeysTrait` a implementovat `HasPasskeys`
+(PasskeyService na ten interface spoléhá):
+
+```php
+// app/Model/Entities/Identity.php — přidat k existující entitě
+use ADT\FancyAdmin\Model\Entities\IdentityPasskeysTrait;
+use ADT\FancyAdmin\Model\Entities\Traits\HasPasskeys;
+
+#[ORM\Entity]
+class Identity extends BaseEntity implements \ADT\FancyAdmin\Model\Entities\Identity, HasPasskeys /* , ... */
+{
+    use IdentityTrait;
+    use IdentityPasskeysTrait;
+}
+```
 
 ```php
 // app/Model/Entities/Passkey.php
@@ -1319,9 +1336,9 @@ class Passkey extends BaseEntity implements \ADT\FancyAdmin\Model\Entities\Passk
 | `createdAt` | DATETIME | Vytvořeno |
 | `lastUsedAt` | DATETIME, nullable | Poslední přihlášení klíčem |
 
-`IdentityTrait` navíc přidává do tabulky `identity` nullable sloupec `passkey_user_handle`
+`IdentityPasskeysTrait` přidává do tabulky `identity` nullable sloupec `passkey_user_handle`
 (BINARY(32)) — náhodný opaque WebAuthn user handle, generovaný při registraci prvního klíče
-(autentikátoru se nikdy neposílá interní ID identity).
+(autentikátoru se nikdy neposílá interní ID identity) — a inverzní vazbu `getPasskeys()`.
 
 ### 19.4 Query + factory
 

--- a/src/DI/FancyAdminExtension.php
+++ b/src/DI/FancyAdminExtension.php
@@ -13,7 +13,9 @@ use ADT\FancyAdmin\Model\Entities\Enums\AclResourceNameEnum;
 use ADT\FancyAdmin\Model\Entities\AclRole;
 use ADT\FancyAdmin\Model\Entities\AclRoleTrait;
 use ADT\FancyAdmin\Model\Entities\Identity;
+use ADT\FancyAdmin\Model\Entities\IdentityPasskeysTrait;
 use ADT\FancyAdmin\Model\Entities\IdentityTrait;
+use ADT\FancyAdmin\Model\Entities\Traits\HasPasskeys;
 use ADT\FancyAdmin\Model\Entities\Profile;
 use ADT\FancyAdmin\Model\Entities\ProfileTrait;
 use ADT\FancyAdmin\Model\FancyAdmin;
@@ -196,6 +198,7 @@ class FancyAdminExtension extends CompilerExtension implements TranslationProvid
 			AclResourceTrait::class => AclResource::class,
 			AclRoleTrait::class => AclRole::class,
 			IdentityTrait::class => Identity::class,
+			IdentityPasskeysTrait::class => HasPasskeys::class,
 			ProfileTrait::class => Profile::class,
 		];
 

--- a/src/Model/Entities/Identity.php
+++ b/src/Model/Entities/Identity.php
@@ -57,9 +57,6 @@ interface Identity extends DoctrineAuthenticatorIdentity, IsActiveInterface, Ent
 	public function getSso(): ?Sso;
 	public function setSso(?Sso $sso): static;
 
-	public function getPasskeyUserHandle(): ?string;
-	public function setPasskeyUserHandle(?string $passkeyUserHandle): static;
-
 	public function getFullName(): string;
 	public function getGravatar(): string;
 	public function getAccounts(): array;

--- a/src/Model/Entities/IdentityPasskeysTrait.php
+++ b/src/Model/Entities/IdentityPasskeysTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ADT\FancyAdmin\Model\Entities;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+
+trait IdentityPasskeysTrait
+{
+	#[ORM\OneToMany(targetEntity: 'Passkey', mappedBy: 'identity')]
+	protected Collection $passkeys;
+
+	// Náhodný opaque WebAuthn user handle, generovaný při registraci prvního klíče —
+	// autentikátoru se nikdy neposílá interní ID identity
+	#[ORM\Column(type: 'binary', length: 32, nullable: true, options: ['fixed' => true])]
+	protected mixed $passkeyUserHandle = null;
+
+	/**
+	 * @return Passkey[]
+	 */
+	public function getPasskeys(): array
+	{
+		// konstruktor s inicializací kolekcí žije v IdentityTrait — u nové entity
+		// je property neinicializovaná, ??= ji bezpečně doplní
+		$this->passkeys ??= new ArrayCollection();
+		return $this->passkeys->toArray();
+	}
+
+	public function getPasskeyUserHandle(): ?string
+	{
+		if ($this->passkeyUserHandle === null) {
+			return null;
+		}
+		if (is_resource($this->passkeyUserHandle)) {
+			rewind($this->passkeyUserHandle);
+			return (string) stream_get_contents($this->passkeyUserHandle);
+		}
+		return (string) $this->passkeyUserHandle;
+	}
+
+	public function setPasskeyUserHandle(?string $passkeyUserHandle): static
+	{
+		$this->passkeyUserHandle = $passkeyUserHandle;
+		return $this;
+	}
+}

--- a/src/Model/Entities/IdentityTrait.php
+++ b/src/Model/Entities/IdentityTrait.php
@@ -77,11 +77,6 @@ trait IdentityTrait
 	#[LoggableProperty]
 	protected Collection $roles;
 
-	// Vazba na passkeys je jen jednosměrná (Passkey ManyToOne identity v PasskeyTrait) —
-	// entita Passkey je v projektu volitelná, Identity na ní nesmí záviset
-	#[ORM\Column(type: 'binary', length: 32, nullable: true, options: ['fixed' => true])]
-	protected mixed $passkeyUserHandle = null;
-
 	#[ORM\Column(nullable: true)]
 	#[LoggableProperty]
 	protected ?DateTimeImmutable $anonymizedAt = null;
@@ -349,21 +344,4 @@ trait IdentityTrait
 		return $this;
 	}
 
-	public function getPasskeyUserHandle(): ?string
-	{
-		if ($this->passkeyUserHandle === null) {
-			return null;
-		}
-		if (is_resource($this->passkeyUserHandle)) {
-			rewind($this->passkeyUserHandle);
-			return (string) stream_get_contents($this->passkeyUserHandle);
-		}
-		return (string) $this->passkeyUserHandle;
-	}
-
-	public function setPasskeyUserHandle(?string $passkeyUserHandle): static
-	{
-		$this->passkeyUserHandle = $passkeyUserHandle;
-		return $this;
-	}
 }

--- a/src/Model/Entities/Traits/HasPasskeys.php
+++ b/src/Model/Entities/Traits/HasPasskeys.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ADT\FancyAdmin\Model\Entities\Traits;
+
+use ADT\FancyAdmin\Model\Entities\Passkey;
+
+interface HasPasskeys
+{
+	/**
+	 * @return Passkey[]
+	 */
+	public function getPasskeys(): array;
+	public function getPasskeyUserHandle(): ?string;
+	public function setPasskeyUserHandle(?string $passkeyUserHandle): static;
+}

--- a/src/Model/Security/Passkey/PasskeyService.php
+++ b/src/Model/Security/Passkey/PasskeyService.php
@@ -7,6 +7,7 @@ namespace ADT\FancyAdmin\Model\Security\Passkey;
 use ADT\DoctrineComponents\EntityManager;
 use ADT\FancyAdmin\Model\Entities\Identity;
 use ADT\FancyAdmin\Model\Entities\Passkey;
+use ADT\FancyAdmin\Model\Entities\Traits\HasPasskeys;
 use ADT\FancyAdmin\Model\FancyAdmin;
 use ADT\FancyAdmin\Model\Queries\Factories\PasskeyQueryFactory;
 use DateTimeImmutable;
@@ -56,6 +57,7 @@ class PasskeyService
 	{
 		$this->assertEnabled();
 		$this->assertNotSso($identity);
+		$identity = $this->assertHasPasskeys($identity);
 
 		// Lazy vygenerování opaque user handle — autentikátoru nikdy neposíláme interní ID identity
 		if ($identity->getPasskeyUserHandle() === null) {
@@ -64,8 +66,7 @@ class PasskeyService
 		}
 
 		$excludeCredentialIds = [];
-		/** @var Passkey $passkey */
-		foreach ($this->getPasskeyQueryFactory()->create()->disableSecurityFilter()->disableAccountFilter()->byIdentity($identity)->fetch() as $passkey) {
+		foreach ($identity->getPasskeys() as $passkey) {
 			$excludeCredentialIds[] = $passkey->getCredentialId();
 		}
 
@@ -209,7 +210,7 @@ class PasskeyService
 			throw new PasskeyException($this->translator->translate('fcadmin.passkeys.errors.unknownKey'));
 		}
 
-		$identity = $passkey->getIdentity();
+		$identity = $this->assertHasPasskeys($passkey->getIdentity());
 
 		if ($userHandle !== null && $userHandle !== '') {
 			$storedHandle = $identity->getPasskeyUserHandle();
@@ -260,6 +261,19 @@ class PasskeyService
 		if (!$this->fancyAdmin->isPasskeyEnabled()) {
 			throw new PasskeyException($this->translator->translate('fcadmin.passkeys.errors.unavailable'));
 		}
+	}
+
+	/**
+	 * @throws RuntimeException pokud entita Identity nepodporuje passkeys —
+	 * chyba konfigurace, ne uživatele
+	 */
+	protected function assertHasPasskeys(Identity $identity): Identity&HasPasskeys
+	{
+		if (!$identity instanceof HasPasskeys) {
+			throw new RuntimeException('Entita ' . $identity::class . ' neimplementuje ' . HasPasskeys::class . ' — přidejte `use IdentityPasskeysTrait` a `implements HasPasskeys` podle README (sekce 19).');
+		}
+
+		return $identity;
 	}
 
 	/**


### PR DESCRIPTION
…erface

- Extract passkey-related ORM fields and methods from IdentityTrait into new IdentityPasskeysTrait
- Add HasPasskeys interface under Traits namespace for type-safe passkey contract
- Remove passkey methods from Identity interface (getPasskeyUserHandle, setPasskeyUserHandle)
- Update FancyAdminExtension imports to reference new IdentityPasskeysTrait and HasPasskeys